### PR TITLE
fixed error on building

### DIFF
--- a/Sources/PerfectHTTPServer/HTTPServer.swift
+++ b/Sources/PerfectHTTPServer/HTTPServer.swift
@@ -223,7 +223,7 @@ public class HTTPServer {
 	func handleConnection(_ net: NetTCP) {
 		
 		var flag = 1
-		_ = setsockopt(net.fd.fd, IPPROTO_TCP, TCP_NODELAY, &flag, UInt32(MemoryLayout<Int32>.size))
+		_ = setsockopt(net.fd.fd, Int32(IPPROTO_TCP), TCP_NODELAY, &flag, UInt32(MemoryLayout<Int32>.size))
 		
 		let req = HTTP11Request(connection: net)
 		req.serverName = self.serverName


### PR DESCRIPTION
fixed following error on build:

/PerfectTemplate/Packages/PerfectHTTPServer-2.0.1/Sources/PerfectHTTPServer/HTTPServer.swift:2                }
26:29: error: cannot convert value of type 'Int' to expected argument type 'Int32'
                _ = setsockopt(net.fd.fd, IPPROTO_TCP, TCP_NODELAY, &flag, UInt32(MemoryLayout<Int32>.size))
                                          ^~~~~~~~~~~
                                          Int32(     )
<unknown>:0: error: build had 1 command failures