### PR TITLE
Enable client CA Validation part 2/2

### DIFF
--- a/Sources/PerfectHTTPServer/HTTPServer.swift
+++ b/Sources/PerfectHTTPServer/HTTPServer.swift
@@ -65,7 +65,9 @@ public class HTTPServer {
 	/// This is important if utilizing the `HTTPRequest.serverName` property.
 	public var serverName = ""
 	public var ssl: (sslCert: String, sslKey: String)?
-	
+	public var caCert: String?
+	public var certVerifyMode: OpenSSLVerifyMode?
+
 	private var requestFilters = [[HTTPRequestFilter]]()
 	private var responseFilters = [[HTTPResponseFilter]]()
 	
@@ -163,6 +165,16 @@ public class HTTPServer {
 				"ECDHE-RSA-AES256-SHA",
 				"ECDHE-ECDSA-AES256-SHA"
 			]
+
+			if
+				let verifyMode = certVerifyMode,
+				let cert = caCert, verifyMode != .sslVerifyNone {
+					guard socket.setClientCA(path: cert, verifyMode: verifyMode) else {
+						let code = Int32(socket.errorCode())
+						throw PerfectError.networkError(code, "Error setting clientCA : \(socket.errorStr(forCode: code))")
+					}
+			}
+      
 			guard socket.useCertificateChainFile(cert: cert) else {
 				let code = Int32(socket.errorCode())
 				throw PerfectError.networkError(code, "Error setting certificate chain file: \(socket.errorStr(forCode: code))")


### PR DESCRIPTION
Possibility to verify Certificate Authority just like we set the port or the ssl property with these 2 new HTTPServer properties: caCert and certVerifyMode.

This is part 2 for this: https://github.com/PerfectlySoft/Perfect-Net/pull/5