### PR TITLE
Support changing TLSMethod, enabling overrides from external projects, use PEM strings for SSL vs files

### DIFF
--- a/Sources/PerfectHTTPServer/HTTPServer.swift
+++ b/Sources/PerfectHTTPServer/HTTPServer.swift
@@ -239,7 +239,7 @@ open class HTTPServer {
 		}
 	}
 	
-	func handleConnection(_ net: NetTCP) {
+	open func handleConnection(_ net: NetTCP) {
 		#if os(Linux)
 			var flag = 1
 			_ = setsockopt(net.fd.fd, Int32(IPPROTO_TCP), TCP_NODELAY, &flag, UInt32(MemoryLayout<Int32>.size))

--- a/Sources/PerfectHTTPServer/HTTPServer.swift
+++ b/Sources/PerfectHTTPServer/HTTPServer.swift
@@ -30,9 +30,9 @@ import PerfectHTTP
 #endif
 
 /// Stand-alone HTTP server.
-public class HTTPServer {
+open class HTTPServer {
 	
-	private var net: NetTCP?
+	public var net: NetTCP?
 	
 	/// The directory in which web documents are sought.
 	/// Setting the document root will add a default URL route which permits
@@ -149,9 +149,9 @@ public class HTTPServer {
 	}
 	
 	/// Bind the server to the designated address/port
-	public func bind() throws {
+  open func bind(tlsMethod: TLSMethod? = .tlsV1_2) throws {
 		if let (cert, key) = ssl {
-			let socket = NetTCPSSL()
+      let socket = NetTCPSSL(tlsMethod: tlsMethod ?? .tlsV1_2)
 			try socket.bind(port: serverPort, address: serverAddress)
 			socket.cipherList = self.cipherList
 			

--- a/Sources/PerfectHTTPServer/HTTPServer.swift
+++ b/Sources/PerfectHTTPServer/HTTPServer.swift
@@ -151,7 +151,8 @@ open class HTTPServer {
 	/// Bind the server to the designated address/port
   open func bind(tlsMethod: TLSMethod? = .tlsV1_2) throws {
 		if let (cert, key) = ssl {
-      let socket = NetTCPSSL(tlsMethod: tlsMethod ?? .tlsV1_2)
+      let socket = NetTCPSSL()
+      socket.tlsMethod = tlsMethod ?? .tlsV1_2
 			try socket.bind(port: serverPort, address: serverAddress)
 			socket.cipherList = self.cipherList
 			

--- a/Sources/PerfectHTTPServer/HTTPServer.swift
+++ b/Sources/PerfectHTTPServer/HTTPServer.swift
@@ -150,10 +150,10 @@ open class HTTPServer {
 	}
 	
 	/// Bind the server to the designated address/port
-  open func bind() throws {
+	open func bind() throws {
 		if let (cert, key) = ssl {
-      let socket = NetTCPSSL()
-      socket.tlsMethod = self.tlsMethod
+			let socket = NetTCPSSL()
+			socket.tlsMethod = self.tlsMethod
 			try socket.bind(port: serverPort, address: serverAddress)
 			socket.cipherList = self.cipherList
 			

--- a/Sources/PerfectHTTPServer/HTTPServer.swift
+++ b/Sources/PerfectHTTPServer/HTTPServer.swift
@@ -67,7 +67,8 @@ open class HTTPServer {
 	public var ssl: (sslCert: String, sslKey: String)?
 	public var caCert: String?
 	public var certVerifyMode: OpenSSLVerifyMode?
-	
+	public var tlsMethod: TLSMethod = .tlsV1_2
+  
 	public var cipherList = [
 		"ECDHE-ECDSA-AES256-GCM-SHA384",
 		"ECDHE-ECDSA-AES128-GCM-SHA256",
@@ -149,10 +150,10 @@ open class HTTPServer {
 	}
 	
 	/// Bind the server to the designated address/port
-  open func bind(tlsMethod: TLSMethod? = .tlsV1_2) throws {
+  open func bind() throws {
 		if let (cert, key) = ssl {
       let socket = NetTCPSSL()
-      socket.tlsMethod = tlsMethod ?? .tlsV1_2
+      socket.tlsMethod = self.tlsMethod
 			try socket.bind(port: serverPort, address: serverAddress)
 			socket.cipherList = self.cipherList
 			


### PR DESCRIPTION
Support for inputting PEM strings for SSL (not just files)
Enables us to change the TLSMethod used
[Optional]: Exposes NetTCP and a few other functions like handleConnection so we could still forward some input not necessary coming from HTTP but still want to use the HTTPS server pipeline - Let me know if you don't want to merge this in and if its too custom - its definitely useful though!