### PR TITLE
modify to compile with swift 4

### DIFF
--- a/Sources/PerfectCHTTPParser/include/module.modulemap
+++ b/Sources/PerfectCHTTPParser/include/module.modulemap
@@ -1,5 +1,4 @@
 module PerfectCHTTPParser {
     header "http_parser.h"
-    link "PerfectCHTTPParser"
     export *
 }

--- a/Sources/PerfectCZlib/include/module.modulemap
+++ b/Sources/PerfectCZlib/include/module.modulemap
@@ -1,5 +1,4 @@
 module PerfectCZlib {
     header "czlib.h"
-    link "PerfectCZlib"
     export *
 }


### PR DESCRIPTION
swift 4 will not build an executable with a link line in C modules in the modulemap. Swift 3.1 has no problem building a project if this line is removed.