### PR TITLE
Remove warnings if on Swift 4.2 or higher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ playground.xcworkspace
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
 # Packages/
 .build/
+Package.resolved
 
 # CocoaPods
 #

--- a/Sources/PerfectHTTPServer/HTTP2/HTTP2Session.swift
+++ b/Sources/PerfectHTTPServer/HTTP2/HTTP2Session.swift
@@ -65,13 +65,13 @@ class HTTP2Session: Hashable, HTTP2NetErrorDelegate, HTTP2FrameReceiver {
 		return lhs.net.fd.fd == rhs.net.fd.fd
 	}
 	
-    #if swift(>=4.2)
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(Int(net.fd.fd))
-    }
-    #else
-	var hashValue: Int { return Int(net.fd.fd) }
-    #endif
+	#if swift(>=4.2)
+		func hash(into hasher: inout Hasher) {
+			hasher.combine(Int(net.fd.fd))
+		}
+	#else
+		var hashValue: Int { return Int(net.fd.fd) }
+	#endif
     
 	let net: NetTCP
 	let server: HTTPServer

--- a/Sources/PerfectHTTPServer/HTTP2/HTTP2Session.swift
+++ b/Sources/PerfectHTTPServer/HTTP2/HTTP2Session.swift
@@ -65,8 +65,14 @@ class HTTP2Session: Hashable, HTTP2NetErrorDelegate, HTTP2FrameReceiver {
 		return lhs.net.fd.fd == rhs.net.fd.fd
 	}
 	
+    #if swift(>=4.2)
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(Int(net.fd.fd))
+    }
+    #else
 	var hashValue: Int { return Int(net.fd.fd) }
-	
+    #endif
+    
 	let net: NetTCP
 	let server: HTTPServer
 	var debug = false


### PR DESCRIPTION
- Use hash(into:) if running on Swift Version 4.2 or higher